### PR TITLE
Update _quarto.yml

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,7 +8,7 @@ website:
     style: headline
     palette: dark
 
-  repo-url: https://github.com/quarto-dev/quarto-demo
+  repo-url: https://github.com/AlbertProfe/wiki
   repo-actions: [edit, issue]
 
   navbar:


### PR DESCRIPTION
`repo-url` was pointing to the `quarto-dev` repository, thus breaking all GitHub actions `[edit, issue]` on any page.