### PR TITLE
Correción de identación en menú izq de Linux

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -92,7 +92,7 @@ website:
             - linux/linux-what-basics.qmd
             - linux/linux-what-sudo.qmd
             - linux/linux-what-pipes.qmd
-             - linux/linux-what-filesys.qmd
+            - linux/linux-what-filesys.qmd
             - linux/linux-what-vm.qmd
         - text: "---"  
         - section: "Linux: distros"


### PR DESCRIPTION
Archivo quarto.yml --> Línea 95 un espacio identado de más no permite acceder al submenú izquierdo